### PR TITLE
v1.1.0: Added zone_facts, zone_meta_facts, and record_facts modules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ v1.1.0
 Release Summary
 ---------------
 
-| Release Date: 2025-03-21
+| Release Date: 2025-03-20
 | Added support for zone_facts, zone_meta_facts, and record_facts modules
 
 New Modules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Ultradns Collection Release Notes
 
 .. contents:: Topics
 
+v1.1.0
+======
+
+Release Summary
+---------------
+
+| Release Date: 2025-03-21
+| Added support for zone_facts module
+
+New Modules
+-----------
+
+- zone_facts - Get facts about zones in UltraDNS
+
 v1.0.3
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,12 +11,14 @@ Release Summary
 ---------------
 
 | Release Date: 2025-03-21
-| Added support for zone_facts module
+| Added support for zone_facts, zone_meta_facts, and record_facts modules
 
 New Modules
 -----------
 
 - zone_facts - Get facts about zones in UltraDNS
+- zone_meta_facts - Get metadata for specific zones in UltraDNS
+- record_facts - Get facts about DNS records in a zone in UltraDNS
 
 v1.0.3
 ======

--- a/changelogs/fragments/1.1.0.yml
+++ b/changelogs/fragments/1.1.0.yml
@@ -1,5 +1,6 @@
 ---
-release_summary: Added support for zone_facts and zone_meta_facts modules
+release_summary: Added support for zone_facts, zone_meta_facts, and record_facts modules
 new_modules:
   - zone_facts - Get facts about zones in UltraDNS
   - zone_meta_facts - Get metadata for specific zones in UltraDNS
+  - record_facts - Get facts about DNS records in a zone in UltraDNS

--- a/changelogs/fragments/1.1.0.yml
+++ b/changelogs/fragments/1.1.0.yml
@@ -1,4 +1,5 @@
 ---
-release_summary: Added support for zone_facts module
+release_summary: Added support for zone_facts and zone_meta_facts modules
 new_modules:
   - zone_facts - Get facts about zones in UltraDNS
+  - zone_meta_facts - Get metadata for specific zones in UltraDNS

--- a/changelogs/fragments/1.1.0.yml
+++ b/changelogs/fragments/1.1.0.yml
@@ -1,0 +1,4 @@
+---
+release_summary: Added support for zone_facts module
+new_modules:
+  - zone_facts - Get facts about zones in UltraDNS

--- a/changelogs/fragments/1.1.0.yml
+++ b/changelogs/fragments/1.1.0.yml
@@ -1,6 +1,6 @@
 ---
-release_summary: Added support for zone_facts, zone_meta_facts, and record_facts modules
-new_modules:
+major_changes:
   - zone_facts - Get facts about zones in UltraDNS
   - zone_meta_facts - Get metadata for specific zones in UltraDNS
   - record_facts - Get facts about DNS records in a zone in UltraDNS
+release_summary: Added support for zone_facts, zone_meta_facts, and record_facts modules

--- a/examples/record_facts_example.yml
+++ b/examples/record_facts_example.yml
@@ -1,0 +1,140 @@
+---
+# Example playbook to demonstrate the record_facts module
+
+- name: Demonstrate record_facts module usage
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    ultra_provider:
+      username: "{{ lookup('env', 'ULTRADNS_USERNAME') }}"
+      password: "{{ lookup('env', 'ULTRADNS_PASSWORD') }}"
+      use_test: "{{ lookup('env', 'ULTRADNS_USE_TEST') | default(false) | bool }}"
+    zone_name: "{{ lookup('env', 'ULTRADNS_TEST_ZONE') | default('example.com') }}"
+
+  tasks:
+    # Basic example: Get all records for a zone
+    - name: Get all records for the zone
+      ultradns.ultradns.record_facts:
+        zone: "{{ zone_name }}"
+        provider: "{{ ultra_provider }}"
+      register: all_records
+
+    # Display summary of records found
+    - name: Display summary of records found
+      ansible.builtin.debug:
+        msg: >-
+          Found {{ all_records.ansible_facts.record_facts | length }} records in zone {{ zone_name }}
+          Note: Record types (rrtype) in the API response include a type number, e.g. 'A (1)', 'AAAA (28)'
+
+    # Example showing how to filter and display specific record type
+    - name: Get only A records by filtering on value
+      ultradns.ultradns.record_facts:
+        zone: "{{ zone_name }}"
+        provider: "{{ ultra_provider }}"
+        # Filter records containing IP addresses starting with 192.168
+        value: "192.168"
+      register: a_records
+
+    # Display filtered records
+    - name: Display A records found
+      ansible.builtin.debug:
+        msg: >-
+          Record: {{ item.ownerName }} ({{ item.rrtype }}),
+          TTL: {{ item.ttl }},
+          Data: {{ item.rdata | join(', ') }}
+      loop: "{{ a_records.ansible_facts.record_facts }}"
+      when: a_records.ansible_facts.record_facts | length > 0 and item.rrtype is regex("^A\\s")
+
+    # Example showing how to filter by owner name
+    - name: Get records for a specific owner
+      ultradns.ultradns.record_facts:
+        zone: "{{ zone_name }}"
+        provider: "{{ ultra_provider }}"
+        # Filter records with "www" in the owner name
+        owner: "www"
+      register: www_records
+
+    # Display records by owner
+    - name: Display www records
+      ansible.builtin.debug:
+        msg: >-
+          Record: {{ item.ownerName }} ({{ item.rrtype }}),
+          TTL: {{ item.ttl }},
+          Data: {{ item.rdata | join(', ') }}
+      loop: "{{ www_records.ansible_facts.record_facts }}"
+      when: www_records.ansible_facts.record_facts | length > 0
+
+    # Example showing how to filter by TTL
+    - name: Get records with a specific TTL
+      ultradns.ultradns.record_facts:
+        zone: "{{ zone_name }}"
+        provider: "{{ ultra_provider }}"
+        # Filter records with TTL of 3600
+        ttl: 3600
+        # TTL filter only applies to RECORDS kind
+        kind: RECORDS
+      register: ttl_records
+
+    # Display records with specific TTL
+    - name: Display records with TTL of 3600
+      ansible.builtin.debug:
+        msg: >-
+          Record: {{ item.ownerName }} ({{ item.rrtype }}),
+          TTL: {{ item.ttl }},
+          Data: {{ item.rdata | join(', ') }}
+      loop: "{{ ttl_records.ansible_facts.record_facts }}"
+      when: ttl_records.ansible_facts.record_facts | length > 0
+
+    # Example showing how to get pool records
+    - name: Get only pool records
+      ultradns.ultradns.record_facts:
+        zone: "{{ zone_name }}"
+        provider: "{{ ultra_provider }}"
+        kind: POOLS
+      register: pool_records
+
+    # Display pool records information
+    - name: Show pool records count
+      ansible.builtin.debug:
+        msg: "Found {{ pool_records.ansible_facts.record_facts | length }} pool records"
+
+    # Example showing reversed order and system-generated records
+    - name: Get records with system-generated status information
+      ultradns.ultradns.record_facts:
+        zone: "{{ zone_name }}"
+        provider: "{{ ultra_provider }}"
+        sys_generated: true  # Include system-generated status information
+        reverse: true
+      register: sys_records
+
+    # Show total count of records with system-generated status
+    - name: Show count of records with system-generated status
+      ansible.builtin.debug:
+        msg: "Found {{ sys_records.ansible_facts.record_facts | length }} records with system-generated status information"
+
+    # Display which records are system-generated
+    - name: Identify system-generated records
+      ansible.builtin.debug:
+        msg: "Record {{ item.ownerName }} ({{ item.rrtype }}) is {{ 'system-generated' if item.systemGenerated[0] else 'user-created' }}"
+      loop: "{{ sys_records.ansible_facts.record_facts }}"
+      when: "'systemGenerated' in item"
+
+    # Display records with multiple rdata entries and their system-generated status
+    - name: Show multi-value records with system-generated status
+      ansible.builtin.debug:
+        msg: >-
+          Record {{ item.ownerName }} ({{ item.rrtype }}) -
+          {% for i in range(item.rdata | length) %}
+          Value {{ i + 1 }}: {{ item.rdata[i] }} ({{ 'system-generated' if item.systemGenerated[i] else 'user-created' }})
+          {% endfor %}
+      loop: "{{ sys_records.ansible_facts.record_facts }}"
+      when: "'systemGenerated' in item and (item.rdata | length) > 1"
+
+    # Export record data to JSON file
+    - name: Export all records to JSON
+      ansible.builtin.copy:
+        content: "{{ all_records.ansible_facts.record_facts | to_nice_json }}"
+        dest: "{{ zone_name }}_records.json"
+        mode: '0644'
+      when: all_records.ansible_facts.record_facts | length > 0

--- a/examples/zone_facts_examples.yml
+++ b/examples/zone_facts_examples.yml
@@ -1,0 +1,61 @@
+---
+# Examples for the ultradns.ultradns.zone_facts module
+
+- name: Demonstrating the use of zone_facts module
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    # Define UltraDNS provider details - typically stored in vault or vars
+    ultra_provider:
+      username: "{{ lookup('env', 'ULTRADNS_USERNAME') }}"
+      password: "{{ lookup('env', 'ULTRADNS_PASSWORD') }}"
+      use_test: "{{ lookup('env', 'ULTRADNS_USE_TEST') | default(false) | bool }}"
+
+  tasks:
+    # Example 1: Get all zones with no filtering
+    - name: Retrieve all zones
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+      register: all_zones
+
+    - name: Display zone count
+      ansible.builtin.debug:
+        msg: "Found {{ all_zones.ansible_facts.zones | length }} zones"
+
+    # Example 2: Filter zones by name (partial match)
+    - name: Get zones matching a name pattern
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        name: "example"  # Will match zones containing "example"
+      register: filtered_zones
+
+    - name: Display filtered zones by name
+      ansible.builtin.debug:
+        msg: "Zone: {{ item.properties.name }}"
+      loop: "{{ filtered_zones.ansible_facts.zones }}"
+      when: filtered_zones.ansible_facts.zones | length > 0
+
+    # Example 3: Filter by zone type
+    - name: Get only PRIMARY zones
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        type: "PRIMARY"
+      register: primary_zones
+
+    # Example 4: Filter by multiple criteria
+    - name: Get ACTIVE PRIMARY zones for specific account
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        type: "PRIMARY"
+        status: "ACTIVE"
+        account: "example-account"
+      register: specific_zones
+
+    # Example 5: Using different network and status filters
+    - name: Get suspended zones on ultra2 network
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        status: "SUSPENDED"
+        network: "ultra2"
+      register: suspended_zones

--- a/examples/zone_facts_report.yml
+++ b/examples/zone_facts_report.yml
@@ -1,0 +1,121 @@
+---
+# Zone reporting playbook using zone_facts module
+
+- name: Generate DNS zone inventory report
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    ultra_provider:
+      username: "{{ lookup('env', 'ULTRADNS_USERNAME') }}"
+      password: "{{ lookup('env', 'ULTRADNS_PASSWORD') }}"
+      use_test: "{{ lookup('env', 'ULTRADNS_USE_TEST') | default(false) | bool }}"
+    report_file: "zone_inventory.csv"
+    report_json: "zone_inventory.json"
+
+  tasks:
+    # Gather facts about all zones across different zone types
+    - name: Gather PRIMARY zones
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        type: "PRIMARY"
+      register: primary_zones
+
+    - name: Gather SECONDARY zones
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        type: "SECONDARY"
+      register: secondary_zones
+
+    - name: Gather ALIAS zones
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        type: "ALIAS"
+      register: alias_zones
+
+    # Display summary of what we found
+    - name: Display summary of zones by type
+      ansible.builtin.debug:
+        msg: |
+          DNS Zone Inventory Summary:
+          - PRIMARY zones: {{ primary_zones.ansible_facts.zones | length }}
+          - SECONDARY zones: {{ secondary_zones.ansible_facts.zones | length }}
+          - ALIAS zones: {{ alias_zones.ansible_facts.zones | length }}
+          - TOTAL zones: {{ (primary_zones.ansible_facts.zones | length) +
+                            (secondary_zones.ansible_facts.zones | length) +
+                            (alias_zones.ansible_facts.zones | length) }}
+
+    # Generate CSV report
+    - name: Create CSV header
+      ansible.builtin.copy:
+        content: "Zone Name,Account Name,Zone Type,Status,Last Modified Date\n"
+        dest: "{{ report_file }}"
+        force: true
+        mode: '0644'
+
+    # Process each zone type separately for the CSV file
+    - name: Append PRIMARY zones to CSV file
+      ansible.builtin.lineinfile:
+        path: "{{ report_file }}"
+        line: >-
+          {{ item.properties.name | default('N/A') }},
+          {{ item.properties.accountName | default('N/A') }},
+          {{ item.properties.type | default('N/A') }},
+          {{ item.properties.status | default('N/A') }},
+          {{ item.properties.lastModifiedDateTime | default('N/A') }}
+        insertafter: EOF
+      loop: "{{ primary_zones.ansible_facts.zones }}"
+      when: item is defined and item.properties is defined
+
+    - name: Append SECONDARY zones to CSV file
+      ansible.builtin.lineinfile:
+        path: "{{ report_file }}"
+        line: >-
+          {{ item.properties.name | default('N/A') }},
+          {{ item.properties.accountName | default('N/A') }},
+          {{ item.properties.type | default('N/A') }},
+          {{ item.properties.status | default('N/A') }},
+          {{ item.properties.lastModifiedDateTime | default('N/A') }}
+        insertafter: EOF
+      loop: "{{ secondary_zones.ansible_facts.zones }}"
+      when: item is defined and item.properties is defined
+
+    - name: Append ALIAS zones to CSV file
+      ansible.builtin.lineinfile:
+        path: "{{ report_file }}"
+        line: >-
+          {{ item.properties.name | default('N/A') }},
+          {{ item.properties.accountName | default('N/A') }},
+          {{ item.properties.type | default('N/A') }},
+          {{ item.properties.status | default('N/A') }},
+          {{ item.properties.lastModifiedDateTime | default('N/A') }}
+        insertafter: EOF
+      loop: "{{ alias_zones.ansible_facts.zones }}"
+      when: item is defined and item.properties is defined
+
+    # Prepare data for JSON report - each zone type separately
+    - name: Create arrays of zone properties for JSON report
+      ansible.builtin.set_fact:
+        primary_properties: "{{ primary_zones.ansible_facts.zones | map(attribute='properties') | list }}"
+        secondary_properties: "{{ secondary_zones.ansible_facts.zones | map(attribute='properties') | list }}"
+        alias_properties: "{{ alias_zones.ansible_facts.zones | map(attribute='properties') | list }}"
+
+    # Combine for JSON report
+    - name: Combine zone properties for JSON report
+      ansible.builtin.set_fact:
+        combined_properties: "{{ primary_properties + secondary_properties + alias_properties }}"
+
+    # Save the complete data as JSON for more detailed reporting
+    - name: Save full zone data as JSON
+      ansible.builtin.copy:
+        content: "{{ combined_properties | to_nice_json }}"
+        dest: "{{ report_json }}"
+        force: true
+        mode: '0644'
+
+    - name: Report generation complete
+      ansible.builtin.debug:
+        msg: |
+          Reports generated:
+          - CSV report: {{ report_file }}
+          - JSON report: {{ report_json }}

--- a/examples/zone_facts_workflow.yml
+++ b/examples/zone_facts_workflow.yml
@@ -1,0 +1,68 @@
+---
+# Practical workflow example using zone_facts module
+
+- name: Zone management workflow using zone_facts
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    ultra_provider:
+      username: "{{ lookup('env', 'ULTRADNS_USERNAME') }}"
+      password: "{{ lookup('env', 'ULTRADNS_PASSWORD') }}"
+      use_test: "{{ lookup('env', 'ULTRADNS_USE_TEST') | default(false) | bool }}"
+    target_account: "example-account"
+    target_domain_pattern: "example"
+
+  tasks:
+    # Step 1: Find all zones matching our criteria
+    - name: Find zones matching our criteria
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        name: "{{ target_domain_pattern }}"
+        type: "PRIMARY"
+        status: "ACTIVE"
+        account: "{{ target_account }}"
+      register: matching_zones
+
+    # Step 2: Summarize what we found
+    - name: Display summary of matching zones
+      ansible.builtin.debug:
+        msg: "Found {{ matching_zones.ansible_facts.zones | length }} zones matching '{{ target_domain_pattern }}' in account '{{ target_account }}'"
+
+    - name: Display zone names
+      ansible.builtin.debug:
+        msg: "- {{ item.properties.name }}"
+      loop: "{{ matching_zones.ansible_facts.zones }}"
+      when: matching_zones.ansible_facts.zones | length > 0 and item is defined and item.properties is defined
+
+    # Step 3: Create a standardized 'www' record in each zone
+    - name: Create www A record in matching zones
+      ultradns.ultradns.record:
+        provider: "{{ ultra_provider }}"
+        zone: "{{ item.properties.name }}"
+        name: "www"
+        type: "A"
+        data: "203.0.113.10"  # Example IP address
+        ttl: 300
+        state: present
+      loop: "{{ matching_zones.ansible_facts.zones }}"
+      when: matching_zones.ansible_facts.zones | length > 0 and item is defined and item.properties is defined
+      register: record_results
+
+    # Step 4: Create a TXT record for verification in each zone
+    - name: Add TXT verification record to each zone
+      ultradns.ultradns.record:
+        provider: "{{ ultra_provider }}"
+        zone: "{{ item.properties.name }}"
+        name: "verify"
+        type: "TXT"
+        data: "verification=example123"
+        ttl: 300
+        state: present
+      loop: "{{ matching_zones.ansible_facts.zones }}"
+      when: matching_zones.ansible_facts.zones | length > 0 and item is defined and item.properties is defined
+
+    # Step 5: Verify our changes by fetching zone records
+    - name: Report on changes made
+      ansible.builtin.debug:
+        msg: "Successfully updated DNS records in {{ record_results.results | selectattr('changed', 'equalto', true) | list | length }} zones."

--- a/examples/zone_meta_facts_example.yml
+++ b/examples/zone_meta_facts_example.yml
@@ -1,0 +1,98 @@
+---
+# Example playbook to demonstrate the zone_meta_facts module
+
+- name: Demonstrate zone_meta_facts module usage
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    ultra_provider:
+      username: "{{ lookup('env', 'ULTRADNS_USERNAME') }}"
+      password: "{{ lookup('env', 'ULTRADNS_PASSWORD') }}"
+      use_test: "{{ lookup('env', 'ULTRADNS_USE_TEST') | default(false) | bool }}"
+
+  tasks:
+    # First, list zones to find some to work with
+    - name: Get a list of PRIMARY zones
+      ultradns.ultradns.zone_facts:
+        provider: "{{ ultra_provider }}"
+        type: PRIMARY
+        name: "test" # Consider using a filter here to limit the number of zones returned
+      register: zone_list
+
+    # Extract zone names from the zone_facts result
+    - name: Extract zone names
+      ansible.builtin.set_fact:
+        zone_names: "{{ zone_list.ansible_facts.zones | map(attribute='properties.name') | list | default([]) }}"
+
+    # Use zone_meta_facts to get detailed metadata for each zone
+    - name: Get detailed metadata for specific zones
+      ultradns.ultradns.zone_meta_facts:
+        provider: "{{ ultra_provider }}"
+        zones: "{{ zone_names }}"
+      register: zone_metadata
+      when: zone_names | length > 0
+
+    # Display the metadata we retrieved
+    - name: Display zone metadata
+      ansible.builtin.debug:
+        msg: >-
+          Zone: {{ item.key }} -
+          Type: {{ item.value.properties.type | default('N/A') }},
+          Status: {{ item.value.properties.status | default('N/A') }},
+          Last Modified: {{ item.value.properties.lastModifiedDateTime | default('N/A') }}
+      loop: "{{ zone_metadata.ansible_facts.zone_meta | default({}) | dict2items }}"
+      when: zone_names | length > 0
+
+    # Example with made-up zones to demonstrate error handling
+    # The module will not fail because fail_on_error is false (the default),
+    # but none of these zones will be in the returned zone_meta dictionary
+    - name: Try to get metadata for non-existent zones
+      ultradns.ultradns.zone_meta_facts:
+        provider: "{{ ultra_provider }}"
+        zones:
+          - "nonexistent1.example.com"
+          - "nonexistent2.example.com"
+        fail_on_error: false  # Don't fail if zones don't exist
+      register: missing_zones
+
+    # Display what we got back for non-existent zones
+    - name: Show results for non-existent zones
+      ansible.builtin.debug:
+        msg: "Retrieved metadata for {{ missing_zones.ansible_facts.zone_meta | length }} zones out of 2 requested"
+
+    # Example with mixed existing and non-existing zones
+    # This demonstrates the module skipping zones that don't exist while
+    # still returning metadata for zones that do exist
+    - name: Get metadata for mixed existing and non-existing zones
+      ultradns.ultradns.zone_meta_facts:
+        provider: "{{ ultra_provider }}"
+        zones: "{{ zone_names[:1] + ['nonexistent.example.com'] }}"
+        fail_on_error: false
+      register: mixed_zones
+      when: zone_names | length > 0
+
+    # Show results from mixed query
+    - name: Show results from mixed query
+      ansible.builtin.debug:
+        msg: "Retrieved metadata for {{ mixed_zones.ansible_facts.zone_meta | length }} zones: {{ mixed_zones.ansible_facts.zone_meta.keys() | list }}"
+      when: zone_names | length > 0
+
+    # Identify which zones were not found
+    - name: Identify non-existent zones
+      ansible.builtin.set_fact:
+        missing_zone_names: "{{ (zone_names[:1] + ['nonexistent.example.com']) | difference(mixed_zones.ansible_facts.zone_meta.keys() | list) }}"
+      when: zone_names | length > 0
+
+    - name: Show which zones were not found
+      ansible.builtin.debug:
+        msg: "The following zones were not found: {{ missing_zone_names | join(', ') }}"
+      when: zone_names | length > 0 and missing_zone_names | length > 0
+
+    # Export zone metadata to JSON file
+    - name: Export zone metadata to JSON
+      ansible.builtin.copy:
+        content: "{{ zone_metadata.ansible_facts.zone_meta | default({}) | to_nice_json }}"
+        dest: "zone_metadata.json"
+        mode: '0644'
+      when: zone_names | length > 0

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@
 
 namespace: "ultradns"
 name: "ultradns"
-version: 1.0.3
+version: 1.1.0
 readme: README.md
 authors:
   - ultradns

--- a/plugins/module_utils/connection.py
+++ b/plugins/module_utils/connection.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 import json
 
-VERSION = "1.0.3"
+VERSION = "1.1.0"
 PREFIX = "udns-ansible-"
 
 

--- a/plugins/module_utils/connection.py
+++ b/plugins/module_utils/connection.py
@@ -1,9 +1,3 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: UltraDNS
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 import json

--- a/plugins/module_utils/connection.py
+++ b/plugins/module_utils/connection.py
@@ -1,3 +1,9 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: UltraDNS
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 import json

--- a/plugins/module_utils/ultraapi.py
+++ b/plugins/module_utils/ultraapi.py
@@ -678,8 +678,8 @@ class UltraDNSModule:
                 returned_count = result['resultInfo'].get('returnedCount', 0)
                 offset += returned_count
                 
-                # If we got fewer records than requested, we're done
-                if returned_count < 1000:
+                # If we've processed all records based on totalCount, we're done
+                if offset >= total_count:
                     break
             else:
                 # If no resultInfo, assume we're done

--- a/plugins/module_utils/ultraapi.py
+++ b/plugins/module_utils/ultraapi.py
@@ -1,9 +1,3 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
-# Copyright: UltraDNS
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 from ansible.module_utils.basic import env_fallback
@@ -397,32 +391,32 @@ class UltraDNSModule:
     def get_zones(self):
         """
         Retrieve all zones from the UltraDNS API with pagination support.
-        
+
         This function handles cursor-based pagination automatically, making multiple
-        requests as needed to retrieve all zones. The default limit is set to 1000 
+        requests as needed to retrieve all zones. The default limit is set to 1000
         zones per request, and filtering is done based on provided parameters.
-        
+
         Returns:
             A list of zone objects from the API response
         """
         # Connect to the API
         if not self.connect():
             return [], self._fail_no_change()
-        
+
         # Initialize empty zones list and base URL
         all_zones = []
         base_path = '/v3/zones'
-        
+
         # Build the query string for filters
         query_parts = []
-        
+
         # Add limit parameter
         query_parts.append('limit=1000')
-        
+
         # Filter by name (partial match)
         if 'name' in self.params and self.params['name']:
             query_parts.append(f"q=name:{self.params['name']}")
-        
+
         # Filter by zone type
         if 'type' in self.params and self.params['type']:
             zone_type = self.params['type']
@@ -433,7 +427,7 @@ class UltraDNSModule:
                     query_parts[q_index] = f"{query_parts[q_index]}+zone_type:{zone_type}"
                 else:
                     query_parts.append(f"q=zone_type:{zone_type}")
-        
+
         # Filter by status
         if 'status' in self.params and self.params['status']:
             status = self.params['status']
@@ -444,7 +438,7 @@ class UltraDNSModule:
                     query_parts[q_index] = f"{query_parts[q_index]}+zone_status:{status}"
                 else:
                     query_parts.append(f"q=zone_status:{status}")
-        
+
         # Filter by account name
         if 'account' in self.params and self.params['account']:
             # URL-encode spaces in account name
@@ -455,7 +449,7 @@ class UltraDNSModule:
                 query_parts[q_index] = f"{query_parts[q_index]}+account_name:{account}"
             else:
                 query_parts.append(f"q=account_name:{account}")
-        
+
         # Filter by network
         if 'network' in self.params and self.params['network']:
             network = self.params['network']
@@ -466,28 +460,28 @@ class UltraDNSModule:
                     query_parts[q_index] = f"{query_parts[q_index]}+network:{network}"
                 else:
                     query_parts.append(f"q=network:{network}")
-        
+
         # Build initial path with query parameters
         path = base_path
         if query_parts:
             path = f"{base_path}?{'&'.join(query_parts)}"
-        
+
         # Track if we have more data to fetch
         has_more = True
         next_path = path
-        
+
         while has_more:
             # Get zones with current path
             result = self.connection.get(next_path)
-            
+
             # Check if response has an error
             if 'errorCode' in result:
                 return [], self._fail_no_change(result['errorMessage'])
-            
+
             # Add zones from current response to our collection
             if 'zones' in result and isinstance(result['zones'], list):
                 all_zones.extend(result['zones'])
-            
+
             # Check for cursorInfo to determine if more data is available
             if 'cursorInfo' in result and result['cursorInfo'].get('next'):
                 cursor = result['cursorInfo']['next']
@@ -495,7 +489,7 @@ class UltraDNSModule:
                 if '?' in next_path:
                     if 'cursor=' in next_path:
                         # Replace existing cursor parameter
-                        next_path = next_path.split('cursor=')[0] + f"cursor={cursor}"
+                        next_path = next_path.split('cursor=', maxsplit=1)[0] + f"cursor={cursor}"
                     else:
                         # Add cursor parameter
                         next_path = f"{next_path}&cursor={cursor}"
@@ -504,18 +498,18 @@ class UltraDNSModule:
                     next_path = f"{next_path}?cursor={cursor}"
             else:
                 has_more = False
-        
+
         return all_zones, self._no_change(f"Retrieved {len(all_zones)} zones")
 
     def get_zone_metadata(self):
         """
         Retrieve metadata for a list of specific zones from the UltraDNS API.
-        
+
         This function sends a GET request to /v3/zones/{zone_name} for each zone
         in the provided list and collects the results. If a zone doesn't exist
         or there's an error retrieving it, the function handles this gracefully
         without failing the entire operation.
-        
+
         Returns:
             A dictionary with zone names as keys and their metadata as values,
             plus a result object indicating success or failure
@@ -523,29 +517,29 @@ class UltraDNSModule:
         # Check for required fields
         required = ['zones']
         missing = self._check_params(required)
-        
+
         if missing:
             return {}, self._fail_no_change(f"Missing required fields: {', '.join(missing)}")
-            
+
         # Connect to the API
         if not self.connect():
             return {}, self._fail_no_change()
-            
+
         # Get the list of zones to fetch
         zone_names = self.params['zones']
         if not isinstance(zone_names, list):
             return {}, self._fail_no_change("The 'zones' parameter must be a list of zone names")
-            
+
         # Initialize dictionary to store zone metadata
         zone_metadata = {}
-        
+
         # Determine if we should fail on error
         fail_on_error = self.params.get('fail_on_error', False)
-        
+
         # Fetch metadata for each zone
         for zone_name in zone_names:
             result = self.connection.get(f"/v3/zones/{zone_name}")
-            
+
             # Check if response has an error - might be a dict with errorCode or a list with error object
             if isinstance(result, list) and result and 'errorCode' in result[0]:
                 if fail_on_error:
@@ -561,91 +555,91 @@ class UltraDNSModule:
                     )
                 # If we're not failing on error, log the error and continue
                 continue
-                
+
             # Store the zone metadata
             zone_metadata[zone_name] = result
-            
+
         return zone_metadata, self._no_change(f"Retrieved metadata for {len(zone_metadata)} out of {len(zone_names)} requested zones")
 
     def get_records(self):
         """
         Retrieve RRSet records for a specified zone from the UltraDNS API with offset-based pagination.
-        
+
         This function handles offset-based pagination automatically, making multiple
-        requests as needed to retrieve all records. The default limit is set to 1000 
+        requests as needed to retrieve all records. The default limit is set to 1000
         records per request, and filtering is done based on provided parameters.
-        
+
         Returns:
             A list of RRSet records from the API response plus a result object indicating success or failure
         """
         # Check for required fields
         required = ['zone']
         missing = self._check_params(required)
-        
+
         if missing:
             return [], self._fail_no_change(f"Missing required fields: {', '.join(missing)}")
-            
+
         # Connect to the API
         if not self.connect():
             return [], self._fail_no_change()
-            
+
         # Initialize empty records list and base URL
         all_records = []
         zone_name = self.params['zone']
         base_path = f"/v3/zones/{zone_name}/rrsets"
-        
+
         # Build the query parameters
         query_parts = []
-        
+
         # Always include a limit parameter
         query_parts.append('limit=1000')
-        
+
         # Build the 'q' parameter for filtering
         q_filters = []
-        
+
         # Filter by owner (partial match)
         if 'owner' in self.params and self.params['owner']:
             q_filters.append(f"owner:{self.params['owner']}")
-        
+
         # Filter by TTL (exact match) - only for RECORDS type
         if 'ttl' in self.params and self.params['ttl'] is not None:
             if not self.params.get('kind') or self.params.get('kind') in ['ALL', 'RECORDS']:
                 q_filters.append(f"ttl:{self.params['ttl']}")
-        
+
         # Filter by value (partial match) - only for RECORDS type
         if 'value' in self.params and self.params['value']:
             if not self.params.get('kind') or self.params.get('kind') in ['ALL', 'RECORDS']:
                 q_filters.append(f"value:{self.params['value']}")
-        
+
         # Add q parameter if filters exist
         if q_filters:
             query_parts.append(f"q={'+'.join(q_filters)}")
-        
+
         # Filter by kind (type of RRSets)
         if 'kind' in self.params and self.params['kind']:
             kind = self.params['kind']
             valid_kinds = ['ALL', 'RECORDS', 'POOLS', 'RD_POOLS', 'DIR_POOLS', 'SB_POOLS', 'TC_POOLS']
             if kind in valid_kinds:
                 query_parts.append(f"kind={kind}")
-        
+
         # Add reverse parameter if specified
         if 'reverse' in self.params and self.params['reverse']:
             query_parts.append('reverse=true')
-        
+
         # Add systemGeneratedStatus parameter if specified
         # This adds status indicators (systemGenerated array) to records rather than filtering them
         if 'sys_generated' in self.params and self.params['sys_generated']:
             query_parts.append('systemGeneratedStatus=true')
-        
+
         # Build initial path with query parameters
         path = base_path
         if query_parts:
             path = f"{base_path}?{'&'.join(query_parts)}"
-        
+
         # Track offset and total count for pagination
         offset = 0
         total_count = None
-        
+
         while total_count is None or offset < total_count:
             # Build current request path with offset
             current_path = path
@@ -653,10 +647,10 @@ class UltraDNSModule:
                 current_path += f"&offset={offset}"
             else:
                 current_path += f"?offset={offset}"
-            
+
             # Get records with current path
             result = self.connection.get(current_path)
-            
+
             # Check if response has an error
             if isinstance(result, list) and result and 'errorCode' in result[0]:
                 return [], self._fail_no_change(f"Error retrieving records: {result[0].get('errorMessage', 'Unknown error')}")
@@ -665,24 +659,24 @@ class UltraDNSModule:
                 if result.get('errorCode') == 70002:  # Data not found error code
                     return [], self._no_change("No records found for the specified zone and filters")
                 return [], self._fail_no_change(f"Error retrieving records: {result.get('errorMessage', 'Unknown error')}")
-            
+
             # Extract records from the response
             if 'rrSets' in result:
                 all_records.extend(result['rrSets'])
-            
+
             # Update pagination information
             if 'resultInfo' in result:
                 if total_count is None:
                     total_count = result['resultInfo'].get('totalCount', 0)
-                
+
                 returned_count = result['resultInfo'].get('returnedCount', 0)
                 offset += returned_count
-                
+
                 # If we've processed all records based on totalCount, we're done
                 if offset >= total_count:
                     break
             else:
                 # If no resultInfo, assume we're done
                 break
-        
+
         return all_records, self._no_change(f"Retrieved {len(all_records)} records")

--- a/plugins/modules/record_facts.py
+++ b/plugins/modules/record_facts.py
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: UltraDNS
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: record_facts
+short_description: Get facts about DNS records in a zone in UltraDNS
+version_added: 1.1.0
+description:
+    - Retrieves DNS records for a specific zone from UltraDNS.
+    - Uses the /v3/zones/{zoneName}/rrsets API endpoint with offset-based pagination.
+    - Supports various filtering options (owner, ttl, value).
+    - Returns facts about the records under the C(record_facts) key.
+    - This module is idempotent and does not make any changes.
+author:
+    - "UltraDNS (@ultradns)"
+options:
+    zone:
+        description:
+            - Name of the zone for which to retrieve records.
+        required: true
+        type: str
+    owner:
+        description:
+            - Filter records by owner name (partial match).
+            - Applies to all RRSet types.
+        required: false
+        type: str
+    ttl:
+        description:
+            - Filter records by TTL (exact match).
+            - Only valid for RECORDS RRSet type; ignored for others.
+        required: false
+        type: int
+    value:
+        description:
+            - Filter records by rdata value (partial match).
+            - Only valid for RECORDS RRSet type; ignored for others.
+        required: false
+        type: str
+    kind:
+        description:
+            - Type of RRSets to retrieve.
+        required: false
+        type: str
+        choices: ['ALL', 'RECORDS', 'POOLS', 'RD_POOLS', 'DIR_POOLS', 'SB_POOLS', 'TC_POOLS']
+        default: 'ALL'
+    reverse:
+        description:
+            - If true, returns records in descending order.
+        required: false
+        type: bool
+        default: false
+    sys_generated:
+        description:
+            - If true, includes system-generated status information in the response.
+            - This does not filter to show only system-generated records; it adds an indicator to all records.
+            - When enabled, each RRSet will include a 'systemGenerated' array that indicates if each rdata entry was system-generated.
+        required: false
+        type: bool
+        default: false
+    provider:
+        description:
+            - Dictionary containing connection details.
+        required: true
+        type: dict
+        suboptions:
+            username:
+                description:
+                    - UltraDNS username for API authentication.
+                    - If not set, the ULTRADNS_USERNAME environment variable will be used.
+                required: false
+                type: str
+            password:
+                description:
+                    - UltraDNS password for API authentication.
+                    - If not set, the ULTRADNS_PASSWORD environment variable will be used.
+                required: false
+                type: str
+            use_test:
+                description:
+                    - If set to true, use the UltraDNS test environment.
+                    - If not set, the ULTRADNS_USE_TEST environment variable will be used.
+                required: false
+                type: bool
+                default: false
+notes:
+    - This module returns facts only, not state changes.
+    - Uses offset-based pagination to automatically retrieve all records.
+    - The API may return an error code 70002 (Data not found) if no records match the filters.
+    - In such cases, an empty list is returned rather than failing the play.
+    - Record types (rrtype) in the API response include type numbers, e.g., 'A (1)', 'AAAA (28)'.
+'''
+
+EXAMPLES = '''
+- name: Gather all records for a zone
+  ultradns.ultradns.record_facts:
+    zone: example.com
+    provider: "{{ ultra_provider }}"
+  register: record_data
+
+- name: Display records
+  ansible.builtin.debug:
+    msg: "Found record: {{ item }}"
+  loop: "{{ record_data.ansible_facts.record_facts }}"
+
+- name: Gather A records with a specific owner
+  ultradns.ultradns.record_facts:
+    zone: example.com
+    owner: www        # partial match for owner name
+    provider: "{{ ultra_provider }}"
+  register: www_records
+
+- name: Gather records with specific TTL
+  ultradns.ultradns.record_facts:
+    zone: example.com
+    ttl: 300          # exact match for TTL
+    kind: RECORDS     # TTL filter only applies to RECORDS
+    provider: "{{ ultra_provider }}"
+  register: ttl_records
+
+- name: Gather records with specific value
+  ultradns.ultradns.record_facts:
+    zone: example.com
+    value: 192.168    # partial match for rdata value
+    provider: "{{ ultra_provider }}"
+  register: ip_records
+
+- name: Gather only pool records in reverse order
+  ultradns.ultradns.record_facts:
+    zone: example.com
+    kind: POOLS       # get only pool records
+    reverse: true     # reverse the sort order
+    provider: "{{ ultra_provider }}"
+  register: pool_records
+
+- name: Include system-generated status information
+  ultradns.ultradns.record_facts:
+    zone: example.com
+    sys_generated: true  # adds system-generated status indicators to records
+    provider: "{{ ultra_provider }}"
+  register: system_records
+
+- name: Display records with system-generated status
+  ansible.builtin.debug:
+    msg: "Record {{ item.ownerName }} ({{ item.rrtype }}) is {{ 'system-generated' if item.systemGenerated[0] else 'user-created' }}"
+  loop: "{{ system_records.ansible_facts.record_facts }}"
+  when: "'systemGenerated' in item"
+'''
+
+RETURN = '''
+ansible_facts:
+    description: Facts about the requested DNS records
+    returned: always
+    type: complex
+    contains:
+        record_facts:
+            description: List of RRSet records returned by the API
+            type: list
+            returned: always
+            sample:
+                - ownerName: "www.example.com."
+                  rrtype: "A (1)"  # Note the type number in parentheses
+                  ttl: 300
+                  rdata: ["192.168.1.1"]
+                  systemGenerated: [false]  # Array indicating if each rdata entry was system-generated
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+from ..module_utils.ultraapi import ultra_connection_spec
+from ..module_utils.ultraapi import UltraDNSModule
+
+
+def main():
+    # Arguments for record facts
+    argspec = {
+        'zone': dict(required=True, type='str'),
+        'owner': dict(required=False, type='str'),
+        'ttl': dict(required=False, type='int'),
+        'value': dict(required=False, type='str'),
+        'kind': dict(required=False, type='str', 
+                     choices=['ALL', 'RECORDS', 'POOLS', 'RD_POOLS', 'DIR_POOLS', 'SB_POOLS', 'TC_POOLS'],
+                     default='ALL'),
+        'reverse': dict(required=False, type='bool', default=False),
+        'sys_generated': dict(required=False, type='bool', default=False),
+    }
+
+    # Add the arguments required for connecting to UltraDNS API
+    argspec.update(ultra_connection_spec())
+
+    module = AnsibleModule(argument_spec=argspec)
+    api = UltraDNSModule(module.params)
+
+    # Get records with pagination
+    records, result = api.get_records()
+
+    # Check if there was an error
+    if 'failed' in result and result['failed']:
+        module.fail_json(**result)
+    else:
+        # Return the records as ansible_facts
+        module.exit_json(changed=False, ansible_facts={'record_facts': records})
+
+
+if __name__ == '__main__':
+    main() 

--- a/plugins/modules/record_facts.py
+++ b/plugins/modules/record_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: UltraDNS
+# Copyright: (c) 2024, UltraDNS <info@ultradns.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -68,7 +68,6 @@ options:
     provider:
         description:
             - Dictionary containing connection details.
-        required: true
         type: dict
         suboptions:
             username:
@@ -173,7 +172,6 @@ ansible_facts:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.basic import env_fallback
 from ..module_utils.ultraapi import ultra_connection_spec
 from ..module_utils.ultraapi import UltraDNSModule
 
@@ -185,7 +183,7 @@ def main():
         'owner': dict(required=False, type='str'),
         'ttl': dict(required=False, type='int'),
         'value': dict(required=False, type='str'),
-        'kind': dict(required=False, type='str', 
+        'kind': dict(required=False, type='str',
                      choices=['ALL', 'RECORDS', 'POOLS', 'RD_POOLS', 'DIR_POOLS', 'SB_POOLS', 'TC_POOLS'],
                      default='ALL'),
         'reverse': dict(required=False, type='bool', default=False),
@@ -195,7 +193,7 @@ def main():
     # Add the arguments required for connecting to UltraDNS API
     argspec.update(ultra_connection_spec())
 
-    module = AnsibleModule(argument_spec=argspec)
+    module = AnsibleModule(argument_spec=argspec, supports_check_mode=True)
     api = UltraDNSModule(module.params)
 
     # Get records with pagination
@@ -210,4 +208,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() 
+    main()

--- a/plugins/modules/zone_facts.py
+++ b/plugins/modules/zone_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: UltraDNS
+# Copyright: (c) 2024, UltraDNS <info@ultradns.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -10,46 +10,71 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: zone_facts
-author: UltraDNS (@ultradns)
-short_description: Retrieve DNS zone facts from UltraDNS
+short_description: Get facts about zones in UltraDNS
+version_added: 1.1.0
 description:
-    - Retrieve information about DNS zones from UltraDNS without making any changes.
-    - Returns the zones as Ansible facts for use in subsequent plays.
-    - Supports cursor-based pagination and various filtering options.
-version_added: 0.1.0
-extends_documentation_fragment: ultradns.ultradns.ultra_provider
+    - Retrieves DNS zones from UltraDNS with pagination support.
+    - Supports various filtering options (name, type, status, account).
+    - Returns facts about the zones under the C(zones) key.
+    - This module is idempotent and does not make any changes.
+author:
+    - "UltraDNS (@ultradns)"
 options:
     name:
         description:
-            - Filter zones by this name (partial match).
+            - Filter zones by name (partial match).
         required: false
         type: str
     type:
         description:
-            - Filter zones by this type.
+            - Filter zones by type.
         required: false
-        choices: ['PRIMARY', 'SECONDARY', 'ALIAS']
         type: str
+        choices: ['PRIMARY', 'SECONDARY', 'ALIAS']
     status:
         description:
-            - Filter zones by this status.
-            - Defaults to 'ACTIVE' if not specified.
+            - Filter zones by status.
         required: false
-        choices: ['ACTIVE', 'SUSPENDED', 'ALL']
         type: str
+        choices: ['ACTIVE', 'SUSPENDED', 'ALL']
     account:
         description:
-            - Filter zones by this account name.
-            - Spaces in the account name will be URL-encoded automatically.
+            - Filter zones by account name.
         required: false
         type: str
     network:
         description:
-            - Filter zones by this network.
-            - Defaults to 'ultra1' if not specified.
+            - Filter zones by network.
         required: false
-        choices: ['ultra1', 'ultra2']
         type: str
+        choices: ['ultra1', 'ultra2']
+    provider:
+        description:
+            - Dictionary containing connection details.
+        required: false
+        type: dict
+        suboptions:
+            username:
+                description:
+                    - UltraDNS username for API authentication.
+                    - If not set, the ULTRADNS_USERNAME environment variable will be used.
+                required: false
+                type: str
+            password:
+                description:
+                    - UltraDNS password for API authentication.
+                    - If not set, the ULTRADNS_PASSWORD environment variable will be used.
+                required: false
+                type: str
+            use_test:
+                description:
+                    - If set to true, use the UltraDNS test environment.
+                    - If not set, the ULTRADNS_USE_TEST environment variable will be used.
+                required: false
+                type: bool
+                default: false
+notes:
+    - This module returns facts only, not state changes.
 '''
 
 EXAMPLES = '''
@@ -87,7 +112,6 @@ ansible_facts:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.basic import env_fallback
 from ..module_utils.ultraapi import ultra_connection_spec
 from ..module_utils.ultraapi import UltraDNSModule
 
@@ -105,7 +129,7 @@ def main():
     # Add the arguments required for connecting to UltraDNS API
     argspec.update(ultra_connection_spec())
 
-    module = AnsibleModule(argument_spec=argspec)
+    module = AnsibleModule(argument_spec=argspec, supports_check_mode=True)
     api = UltraDNSModule(module.params)
 
     # Get zones with pagination
@@ -120,4 +144,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() 
+    main()

--- a/plugins/modules/zone_facts.py
+++ b/plugins/modules/zone_facts.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: UltraDNS
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: zone_facts
+author: UltraDNS (@ultradns)
+short_description: Retrieve DNS zone facts from UltraDNS
+description:
+    - Retrieve information about DNS zones from UltraDNS without making any changes.
+    - Returns the zones as Ansible facts for use in subsequent plays.
+    - Supports cursor-based pagination and various filtering options.
+version_added: 0.1.0
+extends_documentation_fragment: ultradns.ultradns.ultra_provider
+options:
+    name:
+        description:
+            - Filter zones by this name (partial match).
+        required: false
+        type: str
+    type:
+        description:
+            - Filter zones by this type.
+        required: false
+        choices: ['PRIMARY', 'SECONDARY', 'ALIAS']
+        type: str
+    status:
+        description:
+            - Filter zones by this status.
+            - Defaults to 'ACTIVE' if not specified.
+        required: false
+        choices: ['ACTIVE', 'SUSPENDED', 'ALL']
+        type: str
+    account:
+        description:
+            - Filter zones by this account name.
+            - Spaces in the account name will be URL-encoded automatically.
+        required: false
+        type: str
+    network:
+        description:
+            - Filter zones by this network.
+            - Defaults to 'ultra1' if not specified.
+        required: false
+        choices: ['ultra1', 'ultra2']
+        type: str
+'''
+
+EXAMPLES = '''
+- name: Gather zone facts
+  ultradns.ultradns.zone_facts:
+    name: example        # optional filter
+    type: PRIMARY        # optional filter
+    status: ALL          # optional filter
+    account: myaccount   # optional filter
+    provider: "{{ ultra_provider }}"
+  register: zone_data
+
+- name: Display zones
+  ansible.builtin.debug:
+    msg: "Found zone: {{ item.properties.name }}"
+  loop: "{{ zone_data.ansible_facts.zones }}"
+'''
+
+RETURN = '''
+ansible_facts:
+    description: Facts about the zones
+    returned: always
+    type: complex
+    contains:
+        zones:
+            description: List of zones returned by the API
+            type: list
+            returned: always
+            sample:
+                - properties:
+                    name: example.com.
+                    accountName: example
+                    type: PRIMARY
+                    status: ACTIVE
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+from ..module_utils.ultraapi import ultra_connection_spec
+from ..module_utils.ultraapi import UltraDNSModule
+
+
+def main():
+    # Arguments for zone facts
+    argspec = {
+        'name': dict(required=False, type='str'),
+        'type': dict(required=False, type='str', choices=['PRIMARY', 'SECONDARY', 'ALIAS']),
+        'status': dict(required=False, type='str', choices=['ACTIVE', 'SUSPENDED', 'ALL']),
+        'account': dict(required=False, type='str'),
+        'network': dict(required=False, type='str', choices=['ultra1', 'ultra2']),
+    }
+
+    # Add the arguments required for connecting to UltraDNS API
+    argspec.update(ultra_connection_spec())
+
+    module = AnsibleModule(argument_spec=argspec)
+    api = UltraDNSModule(module.params)
+
+    # Get zones with pagination
+    zones, result = api.get_zones()
+
+    # Check if there was an error
+    if 'failed' in result and result['failed']:
+        module.fail_json(**result)
+    else:
+        # Return the zones as ansible_facts
+        module.exit_json(changed=False, ansible_facts={'zones': zones})
+
+
+if __name__ == '__main__':
+    main() 

--- a/plugins/modules/zone_meta_facts.py
+++ b/plugins/modules/zone_meta_facts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, UltraDNS <info@ultradns.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: zone_meta_facts
+short_description: Get metadata for specific zones in UltraDNS
+version_added: 1.1.0
+description:
+    - Retrieves detailed metadata for specified zone names from UltraDNS.
+    - Uses the /v3/zones/{zone_name} API endpoint for each zone.
+    - Returns facts about the zones under the C(zone_meta) key.
+    - This module is idempotent and does not make any changes.
+    - When a zone does not exist, the API returns an error code 1801 with message "Zone does not exist in the system."
+    - By default, these errors are handled gracefully (zones are skipped) and do not cause the module to fail.
+author:
+    - "UltraDNS (@ultradns)"
+options:
+    zones:
+        description:
+            - List of zone names for which to retrieve metadata.
+            - Each zone name will be used in an individual API call.
+        required: true
+        type: list
+        elements: str
+    fail_on_error:
+        description:
+            - If true, the module will fail if any zone metadata cannot be retrieved.
+            - If false, zones that cause errors (like non-existent zones) will be skipped and noted in the return message.
+            - Common error is code 1801 "Zone does not exist in the system" for non-existent zones.
+        required: false
+        type: bool
+        default: false
+    provider:
+        description:
+            - Dictionary containing connection details.
+        required: true
+        type: dict
+        suboptions:
+            username:
+                description:
+                    - UltraDNS username for API authentication.
+                    - If not set, the ULTRADNS_USERNAME environment variable will be used.
+                required: false
+                type: str
+            password:
+                description:
+                    - UltraDNS password for API authentication.
+                    - If not set, the ULTRADNS_PASSWORD environment variable will be used.
+                required: false
+                type: str
+            use_test:
+                description:
+                    - If set to true, use the UltraDNS test environment.
+                    - If not set, the ULTRADNS_USE_TEST environment variable will be used.
+                required: false
+                type: bool
+                default: false
+notes:
+    - This module returns facts only, not state changes.
+    - For a more general zone listing with filtering, use the C(zone_facts) module.
+'''
+
+EXAMPLES = '''
+- name: Gather specific zones metadata
+  ultradns.ultradns.zone_meta_facts:
+    provider: "{{ ultra_provider }}"
+    zones:
+      - example1.com
+      - example2.com
+      - example3.com
+  register: specific_zones
+
+- name: Display specific zone metadata
+  ansible.builtin.debug:
+    msg: "Metadata for zone {{ item.key }}: {{ item.value }}"
+  loop: "{{ specific_zones.ansible_facts.zone_meta | dict2items }}"
+
+- name: Fail if any zone can't be retrieved
+  ultradns.ultradns.zone_meta_facts:
+    provider: "{{ ultra_provider }}"
+    zones:
+      - example1.com
+      - example2.com
+    fail_on_error: true
+  register: critical_zones
+
+- name: Handle non-existent zones gracefully
+  ultradns.ultradns.zone_meta_facts:
+    provider: "{{ ultra_provider }}"
+    zones:
+      - existing-zone.com
+      - non-existent-zone.com
+    # fail_on_error defaults to false, so non-existent zones are simply skipped
+  register: mixed_zones
+
+- name: Check which zones were successfully retrieved
+  ansible.builtin.debug:
+    msg: "Successfully retrieved {{ mixed_zones.ansible_facts.zone_meta | length }} zones: {{ mixed_zones.ansible_facts.zone_meta.keys() | list }}"
+'''
+
+RETURN = '''
+ansible_facts:
+    description: Facts about the requested zones
+    returned: always
+    type: complex
+    contains:
+        zone_meta:
+            description: Dictionary of zone names with their corresponding metadata
+            type: dict
+            returned: always
+            sample:
+                example.com:
+                    properties:
+                        name: example.com.
+                        accountName: example
+                        type: PRIMARY
+                        status: ACTIVE
+                        lastModifiedDateTime: "2023-08-01T12:34:56Z"
+                    primaryCreateInfo:
+                        createType: NEW
+                        forceImport: true
+                    resourceRecordCount: 12
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+from ..module_utils.ultraapi import ultra_connection_spec
+from ..module_utils.ultraapi import UltraDNSModule
+
+
+def main():
+    # Arguments for zone meta facts
+    argspec = {
+        'zones': dict(required=True, type='list', elements='str'),
+        'fail_on_error': dict(required=False, type='bool', default=False),
+    }
+
+    # Add the arguments required for connecting to UltraDNS API
+    argspec.update(ultra_connection_spec())
+
+    module = AnsibleModule(argument_spec=argspec)
+    api = UltraDNSModule(module.params)
+
+    # Get metadata for the specified zones
+    zone_metadata, result = api.get_zone_metadata()
+
+    # Check if there was an error
+    if 'failed' in result and result['failed']:
+        module.fail_json(**result)
+    else:
+        # Return the zone metadata as ansible_facts
+        module.exit_json(changed=False, ansible_facts={'zone_meta': zone_metadata})
+
+
+if __name__ == '__main__':
+    main() 

--- a/plugins/modules/zone_meta_facts.py
+++ b/plugins/modules/zone_meta_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: UltraDNS
+# Copyright: (c) 2024, UltraDNS <info@ultradns.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -40,7 +40,6 @@ options:
     provider:
         description:
             - Dictionary containing connection details.
-        required: true
         type: dict
         suboptions:
             username:
@@ -130,7 +129,6 @@ ansible_facts:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.basic import env_fallback
 from ..module_utils.ultraapi import ultra_connection_spec
 from ..module_utils.ultraapi import UltraDNSModule
 
@@ -145,7 +143,7 @@ def main():
     # Add the arguments required for connecting to UltraDNS API
     argspec.update(ultra_connection_spec())
 
-    module = AnsibleModule(argument_spec=argspec)
+    module = AnsibleModule(argument_spec=argspec, supports_check_mode=True)
     api = UltraDNSModule(module.params)
 
     # Get metadata for the specified zones
@@ -160,4 +158,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() 
+    main()

--- a/plugins/modules/zone_meta_facts.py
+++ b/plugins/modules/zone_meta_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2024, UltraDNS <info@ultradns.com>
+# Copyright: UltraDNS
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function


### PR DESCRIPTION
This pull request introduces three new modules into the UltraDNS Ansible collection:

- **zone_facts**([Issue#8](https://github.com/ultradns/ultradns-ansible/issues/8)):  
  Retrieves a list of zones by sending GET requests to the `/v3/zones` endpoint. This module supports cursor-based pagination and allows filtering by parameters such as `name`, `type`, `status`, `account`, and `network`. The results are returned as Ansible facts under `ansible_facts.zones`.

- **zone_meta_facts**([Issue#9](https://github.com/ultradns/ultradns-ansible/issues/9)):  
  Retrieves detailed metadata for specific zones using the `/v3/zones/{zone_name}` endpoint. Users can provide a list of zones, and the module will query each one individually. It handles errors gracefully for zones that do not exist and returns the metadata as Ansible facts under `ansible_facts.zone_meta`.

- **record_facts** ([Issue#10](https://github.com/ultradns/ultradns-ansible/issues/10)):  
  Retrieves DNS record sets (RRsets) for a specified zone using the `/v3/zones/{zoneName}/rrsets` endpoint. This module supports offset-based pagination and accepts a variety of filtering options including `ttl`, `owner`, `value`, `kind`, `reverse`, and `sys_generated`. The gathered records are returned as Ansible facts under `ansible_facts.record_facts`.

**Release Summary:**

| **Release Date:** 2025-03-20 |
|----------------------------|

**New Modules:**

- **zone_facts** - Get facts about zones in UltraDNS.
- **zone_meta_facts** - Get metadata for specific zones in UltraDNS.
- **record_facts** - Get facts about DNS records in a zone in UltraDNS.